### PR TITLE
Bug : Added translucent to navigationbar as we had a black background color…

### DIFF
--- a/DailyFeed/Views/Base.lproj/Main.storyboard
+++ b/DailyFeed/Views/Base.lproj/Main.storyboard
@@ -387,7 +387,7 @@
                 <navigationController storyboardIdentifier="InitialNavigationController" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="oWo-5U-Bje" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="DailyFeed" image="logo" id="xue-dU-KaD"/>
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" largeTitles="YES" id="DE7-ZW-YwF">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" largeTitles="YES" id="DE7-ZW-YwF">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="91"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>


### PR DESCRIPTION
**Bug Description :** When displaying large tiles on DailyFeeds we see the NavigtionBar has a black background color

**Fix :** Set the _translucent_ property to true

**ScreenShot Before fix :**

<img width="559" alt="Screenshot 2020-10-07 at 7 36 06 PM" src="https://user-images.githubusercontent.com/9132837/95355450-35508580-08e3-11eb-9284-56fc059bd0aa.png">

**ScreenShot After fix :**

<img width="559" alt="Screenshot 2020-10-07 at 9 22 41 PM" src="https://user-images.githubusercontent.com/9132837/95355497-40a3b100-08e3-11eb-9416-ba5e87424b22.png">
