### PR TITLE
Added translucent to navigationbar as we had a black background color…

### DIFF
--- a/DailyFeed/Views/Base.lproj/Main.storyboard
+++ b/DailyFeed/Views/Base.lproj/Main.storyboard
@@ -387,7 +387,7 @@
                 <navigationController storyboardIdentifier="InitialNavigationController" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="oWo-5U-Bje" sceneMemberID="viewController">
                     <tabBarItem key="tabBarItem" title="DailyFeed" image="logo" id="xue-dU-KaD"/>
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" largeTitles="YES" id="DE7-ZW-YwF">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" largeTitles="YES" id="DE7-ZW-YwF">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="91"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>


### PR DESCRIPTION
**Feature :**
Added translucent to navigationbar

**Description :**
Set the translucent property of navigationbar  to true as we had a black background color when displayed large titles.

**ScreenShot before fix  :**

<img width="559" alt="Screenshot 2020-10-07 at 7 36 06 PM" src="https://user-images.githubusercontent.com/9132837/95539907-38479500-0a0d-11eb-86dd-138faf3a5f56.png">

**ScreenShot After fix  :**

<img width="559" alt="Screenshot 2020-10-07 at 7 35 29 PM" src="https://user-images.githubusercontent.com/9132837/95539914-3c73b280-0a0d-11eb-9218-dfb10e9be346.png">
